### PR TITLE
Fix webpack config to build without babel

### DIFF
--- a/modules/custom-activity/webpack.config.js
+++ b/modules/custom-activity/webpack.config.js
@@ -6,18 +6,20 @@ module.exports = {
   entry: path.resolve(__dirname, 'src/index.js'),
   output: {
     filename: 'custom-activity.js',
-    path: path.resolve(__dirname, 'dist')
+    path: path.resolve(__dirname, 'dist'),
+    clean: true
   },
   mode: 'production',
   module: {
-    rules: [
-      { test: /\.m?js$/, exclude: /(node_modules)/, use: { loader: 'babel-loader', options: { presets: [] } } }
-    ]
+    rules: []
   },
   plugins: [
     new CopyWebpackPlugin({
       patterns: [
-        { from: path.resolve(__dirname, 'html/index.html'), to: path.resolve(__dirname, 'dist/../html/index.html') }
+        {
+          from: path.resolve(__dirname, 'html/index.html'),
+          to: path.resolve(__dirname, 'dist/index.html')
+        }
       ]
     })
   ],


### PR DESCRIPTION
## Summary
- simplify the webpack configuration so the bundle no longer depends on babel-loader
- ensure the dist folder is cleaned and capture the HTML in the build output for distribution

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cadfb27cf48330897011b9023d8729