### PR TITLE
feat: update WhatsApp preview in realtime

### DIFF
--- a/modules/custom-activity/html/index.html
+++ b/modules/custom-activity/html/index.html
@@ -265,6 +265,10 @@
       color: #f8fafc;
     }
 
+    #previewMessage {
+      white-space: pre-line;
+    }
+
     .chat-media {
       border-radius: 16px;
       overflow: hidden;


### PR DESCRIPTION
## Summary
- refresh the WhatsApp preview whenever campaign, sender, template, body, media, or button inputs change
- centralize preview defaults while improving media/button handling for the realtime card
- keep message body formatting in the preview by preserving newline characters

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb8b298c3c83309a624b46575c0599