### PR TITLE
Sync WhatsApp preview with form state

### DIFF
--- a/modules/custom-activity/html/index.html
+++ b/modules/custom-activity/html/index.html
@@ -269,6 +269,19 @@
       white-space: pre-line;
     }
 
+    .preview-token {
+      display: inline-flex;
+      align-items: center;
+      padding: 0 6px;
+      margin: 0 1px;
+      border-radius: 6px;
+      background: rgba(148, 163, 184, 0.22);
+      color: #f8fafc;
+      font-weight: 600;
+      font-size: 0.92em;
+      letter-spacing: 0.01em;
+    }
+
     .chat-media {
       border-radius: 16px;
       overflow: hidden;
@@ -300,6 +313,11 @@
       font-size: 0.85rem;
       text-transform: uppercase;
       letter-spacing: 0.08em;
+    }
+
+    .chat-button .preview-token {
+      background: rgba(15, 118, 110, 0.45);
+      color: #ecfdf5;
     }
 
     .actions {


### PR DESCRIPTION
## Summary
- keep a shared form state so changes immediately update the WhatsApp preview
- render personalization tokens safely and highlight them inside the preview bubble and quick reply
- add styling for preview tokens to keep the message formatting consistent

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb8e7ffd4c8330892a9b8fd4ff6ce0