### PR TITLE
Serve bundled assets for custom activity UI

### DIFF
--- a/modules/custom-activity/app/app.js
+++ b/modules/custom-activity/app/app.js
@@ -1,9 +1,16 @@
 // modules/custom-activity/app/app.js
+const express = require('express');
 const path = require('path');
 // const jwt = require('jsonwebtoken'); // if you plan to verify JB JWT
 
 module.exports = function(app, options = {}) {
   const moduleDirectory = path.join(options.rootDirectory, 'modules', 'custom-activity');
+
+  // Bundled assets (webpack output)
+  app.use(
+    '/modules/custom-activity/dist',
+    express.static(path.join(moduleDirectory, 'dist'))
+  );
 
   // Redirect base → UI
   app.get('/modules/custom-activity/', (req, res) =>

--- a/modules/custom-activity/html/index.html
+++ b/modules/custom-activity/html/index.html
@@ -269,6 +269,19 @@
       white-space: pre-line;
     }
 
+    .preview-token {
+      display: inline-flex;
+      align-items: center;
+      padding: 0 6px;
+      margin: 0 1px;
+      border-radius: 6px;
+      background: rgba(148, 163, 184, 0.22);
+      color: #f8fafc;
+      font-weight: 600;
+      font-size: 0.92em;
+      letter-spacing: 0.01em;
+    }
+
     .chat-media {
       border-radius: 16px;
       overflow: hidden;
@@ -300,6 +313,11 @@
       font-size: 0.85rem;
       text-transform: uppercase;
       letter-spacing: 0.08em;
+    }
+
+    .chat-button .preview-token {
+      background: rgba(15, 118, 110, 0.45);
+      color: #ecfdf5;
     }
 
     .actions {


### PR DESCRIPTION
## Summary
- serve the webpack `dist` directory so the custom activity inspector can load the compiled script
- ensure the WhatsApp preview bindings initialize and react to form edits now that the client bundle is loaded

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb8e7ffd4c8330892a9b8fd4ff6ce0