### PR TITLE
Add dynamic WhatsApp configuration with DE mapping

### DIFF
--- a/modules/custom-activity/config/config-json.js
+++ b/modules/custom-activity/config/config-json.js
@@ -42,7 +42,7 @@ module.exports = function configJSON(req) {
             sendType: 'immediate'
           },
           {
-            recipientTo: '919999999999'
+            recipientTo: '{{Contact.Attribute.DE.Mobile}}'
           },
           {
             senderFrom: '919999999999'

--- a/modules/custom-activity/html/index.html
+++ b/modules/custom-activity/html/index.html
@@ -419,6 +419,12 @@
           <label for="campaignName">Campaign name<span class="hint"> · shown internally</span></label>
           <input id="campaignName" type="text" placeholder="Winter WhatsApp blast" autocomplete="off" required/>
         </div>
+        <div class="field-group">
+          <label for="recipientTo">Recipient mobile<span class="hint"> · map a Data Extension field</span></label>
+          <input id="recipientTo" type="text" placeholder="{{Contact.Attribute.DE.Mobile}}" list="recipientOptions" autocomplete="off" required/>
+          <datalist id="recipientOptions"></datalist>
+          <div class="hint">Select from the Data Extension attributes or paste a JB data binding token.</div>
+        </div>
         <div class="field-row">
           <div class="field-group">
             <label for="senderName">Sender profile</label>
@@ -479,6 +485,7 @@
             </div>
             <div class="chat-thread">
               <span class="chat-meta" id="previewCampaign">Adidas India – Welcome Offer</span>
+              <span class="chat-meta" id="previewSendTiming">Sending immediately</span>
               <div class="chat-bubble" id="previewBubble">
                 <div class="chat-media" id="previewMedia">
                   <img alt="Campaign media preview" id="previewMediaImage" src=""/>


### PR DESCRIPTION
## Summary
- add Data Extension-aware recipient mapping with schema-powered suggestions and live preview updates for campaign fields
- surface send timing in the WhatsApp preview and ensure all configuration inputs update the preview instantly
- harden Journey Builder validation by checking execute payload requirements and defaulting inArguments to contact attributes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ccf941e7c88330ae3685837335ef4d