### PR TITLE
Add config inspector URL to config json

### DIFF
--- a/modules/custom-activity/config/config-json.js
+++ b/modules/custom-activity/config/config-json.js
@@ -70,6 +70,7 @@ module.exports = function configJSON(req) {
     },
     userInterfaces: {
       configInspector: {
+        url: toAbsoluteUrl(origin, activityPath, 'index.html'),
         size: 'scm-lg' // inspector size
       }
     },


### PR DESCRIPTION
## Summary
- point the config inspector UI at the activity's inspector page while keeping the configured size

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0f2b30bac83309db78431b8ef27e4