### PR TITLE
feat: allow overriding activity public url

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -71,6 +71,7 @@ PORT=1111
 # APP_ENV=development              # uncomment to force the local dev API
 
 
+ACTIVITY_PUBLIC_URL=https://your-domain.example.com/modules/custom-activity
 API_URL_DEV=http://localhost:3000/api/message
 API_URL_PROD=https://sfmc.comsensetechnologies.com/api/message
 # API_URL=                        # optional explicit override for both envs
@@ -91,6 +92,7 @@ MESSAGE_METADATA_VERSION=v1.0.9
 # JB_PUBLIC_KEY=-----BEGIN PUBLIC KEY----- (optional, for JWT verification)
 ```
 
+Set `ACTIVITY_PUBLIC_URL` when Journey Builder needs to see a specific HTTPS base URL (for example when running behind a reverse proxy or tunnelling a local instance).
 
 By default the service uses the production URL. Set `APP_ENV=development` (or `NODE_ENV=development`) when you specifically want to call a local mock. You can still provide a single `API_URL` to override both when needed.
 


### PR DESCRIPTION
## Summary
- allow config.json to use a forced HTTPS origin and path when ACTIVITY_PUBLIC_URL or PUBLIC_URL is set
- document the new ACTIVITY_PUBLIC_URL environment variable for Journey Builder deployments

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d10a9229588330b58506a9853284c8