### PR TITLE
Set default public URL to sfmc.comsensetechnologies.com

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,8 @@
 PORT=1111
 
+# Public HTTPS base URL used by Journey Builder when requesting config.json and assets
+ACTIVITY_PUBLIC_URL=https://sfmc.comsensetechnologies.com/modules/custom-activity
+
 # APP_ENV=development # uncomment to force local/dev behaviour
 API_URL_DEV=http://localhost:3000/api/message
 API_URL_PROD=https://sfmc.comsensetechnologies.com/api/message

--- a/modules/custom-activity/config/config-json.js
+++ b/modules/custom-activity/config/config-json.js
@@ -1,7 +1,8 @@
 // modules/custom-activity/config/config-json.js
 const DEFAULT_ACTIVITY_PATH = '/modules/custom-activity';
+const DEFAULT_PUBLIC_URL = 'https://sfmc.comsensetechnologies.com/modules/custom-activity';
 
-const envPublicUrl = process.env.ACTIVITY_PUBLIC_URL || process.env.PUBLIC_URL;
+const envPublicUrl = process.env.ACTIVITY_PUBLIC_URL || process.env.PUBLIC_URL || DEFAULT_PUBLIC_URL;
 const envConfig = parsePublicUrl(envPublicUrl);
 const ENV_ORIGIN = envConfig?.origin;
 const ENV_PATH = envConfig?.path;

--- a/readme.md
+++ b/readme.md
@@ -71,7 +71,7 @@ PORT=1111
 # APP_ENV=development              # uncomment to force the local dev API
 
 
-ACTIVITY_PUBLIC_URL=https://your-domain.example.com/modules/custom-activity
+ACTIVITY_PUBLIC_URL=https://sfmc.comsensetechnologies.com/modules/custom-activity
 API_URL_DEV=http://localhost:3000/api/message
 API_URL_PROD=https://sfmc.comsensetechnologies.com/api/message
 # API_URL=                        # optional explicit override for both envs


### PR DESCRIPTION
## Summary
- default the custom activity config to the sfmc.comsensetechnologies.com public URL
- document the public URL in the sample environment file and README for easier setup

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d10caf08d8833092275a6b1db7681f