### PR TITLE
Fix execute response recipient lookup

### DIFF
--- a/modules/custom-activity/app/app.js
+++ b/modules/custom-activity/app/app.js
@@ -129,8 +129,8 @@ module.exports = function(app, options = {}) {
       const out = {
         success: true,
         messageId: responseData.messageId || responseData.id,
-        channel: payload.message.channel || MESSAGE_CHANNEL,
-        recipient: payload.recipient.to,
+        channel: payload?.message?.channel || MESSAGE_CHANNEL,
+        recipient: payload?.message?.recipient?.to,
         timestamp: new Date().toISOString(),
         upstreamStatus: response.status,
         upstreamResponse: responseData,


### PR DESCRIPTION
## Summary
- ensure the execute endpoint formats the recipient using the message payload shape
- guard against missing message properties when building the success response

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d112872be08330b49072b4fbfb7ca4