### PR TITLE
Use request host/path when generating config.json URLs

### DIFF
--- a/modules/custom-activity/config/config-json.js
+++ b/modules/custom-activity/config/config-json.js
@@ -1,8 +1,7 @@
 // modules/custom-activity/config/config-json.js
 const DEFAULT_ACTIVITY_PATH = '/modules/custom-activity';
-const DEFAULT_PUBLIC_URL = 'https://sfmc.comsensetechnologies.com/modules/custom-activity';
 
-const envPublicUrl = process.env.ACTIVITY_PUBLIC_URL || process.env.PUBLIC_URL || DEFAULT_PUBLIC_URL;
+const envPublicUrl = process.env.ACTIVITY_PUBLIC_URL ?? process.env.PUBLIC_URL;
 const envConfig = parsePublicUrl(envPublicUrl);
 const ENV_ORIGIN = envConfig?.origin;
 const ENV_PATH = envConfig?.path;


### PR DESCRIPTION
## Summary
- stop defaulting config.json URLs to a hard-coded hostname when no public URL override is provided
- let config.json URLs mirror the origin and path from the incoming request headers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d122780af08330823d7d0f7be99b84