### PR TITLE
Fix Done button state after hydration

### DIFF
--- a/modules/custom-activity/src/index.js
+++ b/modules/custom-activity/src/index.js
@@ -286,7 +286,11 @@ function onInitActivity(data) {
   hydrateField('recipientTo', inArgs.recipientTo || inArgs.mobile || inArgs.to);
 
   handleInputChange();
-  enableDone(false);
+  const hydratedValid = isValid(formState);
+  const hasInArgs = Object.keys(inArgs || {}).length > 0;
+  const storedValid = hasInArgs ? isValid(inArgs) : false;
+  const shouldEnableDone = hydratedValid || (activity?.metaData?.isConfigured && storedValid);
+  enableDone(shouldEnableDone);
   isHydrating = false;
 }
 


### PR DESCRIPTION
## Summary
- update the initialization logic to respect hydrated values when enabling the Done button
- allow previously configured payloads to keep the Done button enabled if their saved arguments are valid

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d23800c91083309017bed73f69dcfb