### PR TITLE
Handle Journey Builder validation failures gracefully

### DIFF
--- a/modules/custom-activity/app/app.js
+++ b/modules/custom-activity/app/app.js
@@ -102,11 +102,14 @@ module.exports = function(app, options = {}) {
     if (!validation.valid) {
       console.error('validate error:', validation.message);
       withCrossOriginResourcePolicy(res);
-      return res.status(400).json({ message: validation.message });
+      return res.status(200).json({
+        success: false,
+        validationErrors: [validation.message],
+      });
     }
 
     withCrossOriginResourcePolicy(res);
-    return res.status(200).json({});
+    return res.status(200).json({ success: true });
   });
 
   // Publish (journey activated)


### PR DESCRIPTION
## Summary
- change the validate route to always return HTTP 200 responses so Journey Builder recognises the endpoint
- surface validation failures in the response payload via `validationErrors`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d26634661c83308a5a8fddee7ad725