### PR TITLE
Ensure lifecycle routes return success payloads

### DIFF
--- a/modules/custom-activity/app/app.js
+++ b/modules/custom-activity/app/app.js
@@ -91,7 +91,7 @@ module.exports = function(app, options = {}) {
   app.post(route('save'), (req, res) => {
     console.log('save payload:', JSON.stringify(req.body));
     withCrossOriginResourcePolicy(res);
-    return res.status(200).json({});
+    return res.status(200).json({ success: true });
   });
 
   // Validate (pre-publish)
@@ -109,21 +109,21 @@ module.exports = function(app, options = {}) {
     }
 
     withCrossOriginResourcePolicy(res);
-    return res.status(200).json({ success: true });
+    return res.status(200).json({ success: true, validationErrors: [] });
   });
 
   // Publish (journey activated)
   app.post(route('publish'), (req, res) => {
     console.log('publish payload:', JSON.stringify(req.body));
     withCrossOriginResourcePolicy(res);
-    return res.status(200).json({});
+    return res.status(200).json({ success: true });
   });
 
   // Stop (journey stopped)
   app.post(route('stop'), (req, res) => {
     console.log('stop payload:', JSON.stringify(req.body));
     withCrossOriginResourcePolicy(res);
-    return res.status(200).json({});
+    return res.status(200).json({ success: true });
   });
 
   // Execute (runtime: contact reaches step)


### PR DESCRIPTION
## Summary
- return an explicit `{ success: true }` payload from save, publish and stop lifecycle handlers so Journey Builder sees a successful response
- include an empty validationErrors array in the successful validate response to satisfy Journey Builder expectations

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d269ba35c883309f0f3bf92dd62fc9