### PR TITLE
Allow Journey Builder iframe to load custom activity UI

### DIFF
--- a/lib/cross-origin-resource-policy.js
+++ b/lib/cross-origin-resource-policy.js
@@ -1,27 +1,20 @@
-function applyCrossOriginResourcePolicyHeader(res, resourcePath) {
+const CROSS_ORIGIN_VALUE = 'cross-origin';
+
+function applyCrossOriginResourcePolicyHeader(res) {
   if (!res || typeof res.setHeader !== 'function') {
     return;
   }
 
-  const value = isSvgResource(resourcePath) ? 'cross-origin' : 'same-site';
-  res.setHeader('Cross-Origin-Resource-Policy', value);
+  res.setHeader('Cross-Origin-Resource-Policy', CROSS_ORIGIN_VALUE);
 }
 
-function withCrossOriginResourcePolicy(res, headerValue = 'same-site') {
+function withCrossOriginResourcePolicy(res, headerValue = CROSS_ORIGIN_VALUE) {
   if (!res || typeof res.setHeader !== 'function') {
     return res;
   }
 
   res.setHeader('Cross-Origin-Resource-Policy', headerValue);
   return res;
-}
-
-function isSvgResource(resourcePath) {
-  if (!resourcePath || typeof resourcePath !== 'string') {
-    return false;
-  }
-
-  return resourcePath.trim().toLowerCase().endsWith('.svg');
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
- always send the Cross-Origin-Resource-Policy response header as `cross-origin`
- default helper to use the cross-origin header when serving the activity UI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3997d3f3c8330ad8f390e610d073a