### PR TITLE
Handle null-like env overrides for activity paths

### DIFF
--- a/modules/custom-activity/app/app.js
+++ b/modules/custom-activity/app/app.js
@@ -564,6 +564,11 @@ function normaliseMountPath(pathname) {
     return null;
   }
 
+  const lower = trimmed.toLowerCase();
+  if (lower === 'null' || lower === 'undefined') {
+    return null;
+  }
+
   if (trimmed === '/') {
     return '/';
   }

--- a/modules/custom-activity/config/config-json.js
+++ b/modules/custom-activity/config/config-json.js
@@ -192,6 +192,15 @@ function normaliseExtensionKey(value) {
   }
 
   const trimmed = String(value).trim();
+  if (!trimmed) {
+    return '';
+  }
+
+  const lower = trimmed.toLowerCase();
+  if (lower === 'null' || lower === 'undefined') {
+    return '';
+  }
+
   return trimmed;
 }
 
@@ -276,6 +285,11 @@ function normalisePath(pathname) {
 
   const trimmed = pathname.trim();
   if (!trimmed) {
+    return '';
+  }
+
+  const lower = trimmed.toLowerCase();
+  if (lower === 'null' || lower === 'undefined') {
     return '';
   }
 
@@ -374,6 +388,11 @@ function sanitizeExternalHost(candidate) {
 
   const trimmed = String(candidate).trim();
   if (!trimmed) {
+    return '';
+  }
+
+  const lower = trimmed.toLowerCase();
+  if (lower === 'null' || lower === 'undefined') {
     return '';
   }
 


### PR DESCRIPTION
## Summary
- ignore string placeholders like `null` or `undefined` when normalising the custom activity mount path and config path values
- ensure environment-provided extension keys and host overrides drop null-like values to avoid emitting `/null` URLs in config.json
- keep the Express mount path resilient to accidental "null" overrides so the inspector assets resolve correctly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3a1c24fa88330a5fe61c643a6f285