### PR TITLE
Allow Marketing Cloud host fallback for config URLs

### DIFF
--- a/modules/custom-activity/config/config-json.js
+++ b/modules/custom-activity/config/config-json.js
@@ -221,19 +221,16 @@ function resolveOrigin(req = {}) {
   }
 
   const forwardedProto = resolveForwardedProto(req.headers?.['x-forwarded-proto']);
-  const forwardedHostRaw = firstHeaderValue(req.headers?.['x-forwarded-host']);
-  const requestHostRaw = req.get?.('host') || req.headers?.host || '';
+  const forwardedHostCandidates = collectHeaderValues(req.headers?.['x-forwarded-host']);
+  const requestHostCandidates = collectHeaderValues(req.get?.('host') || req.headers?.host || '');
 
-  const forwardedHost = sanitizeExternalHost(forwardedHostRaw);
-  const requestHost = sanitizeExternalHost(requestHostRaw);
+  const hostCandidates = [
+    ...forwardedHostCandidates,
+    ...requestHostCandidates,
+  ];
 
-  const fallbackForwardedHost = sanitizeExternalHost(forwardedHostRaw, { allowProxyHosts: true });
-  const fallbackRequestHost = sanitizeExternalHost(requestHostRaw, { allowProxyHosts: true });
-
-  const host = forwardedHost
-    || requestHost
-    || fallbackForwardedHost
-    || fallbackRequestHost;
+  const host = resolvePrimaryExternalHost(hostCandidates)
+    || resolveExternalHostFallback(hostCandidates);
   const protocol = resolveProtocol({
     forwardedProto,
     requestProtocol: req.protocol,
@@ -411,11 +408,58 @@ function sanitizeExternalHost(candidate, { allowProxyHosts = false } = {}) {
     return '';
   }
 
-  if (!allowProxyHosts && isMarketingCloudProxyHost(hostname)) {
+  const canonicalHost = normaliseExternalHostname(hostname);
+  if (!canonicalHost) {
+    return '';
+  }
+
+  if (!allowProxyHosts && isMarketingCloudProxyHost(canonicalHost)) {
     return '';
   }
 
   return hostname;
+}
+
+function resolvePrimaryExternalHost(candidates = []) {
+  for (const candidate of candidates) {
+    const sanitized = sanitizeExternalHost(candidate);
+    if (sanitized) {
+      return sanitized;
+    }
+  }
+
+  return '';
+}
+
+function resolveExternalHostFallback(candidates = []) {
+  let proxyHost = '';
+
+  for (const candidate of candidates) {
+    if (!candidate) {
+      continue;
+    }
+
+    const sanitized = sanitizeExternalHost(candidate, { allowProxyHosts: true });
+    if (!sanitized) {
+      continue;
+    }
+
+    const canonical = normaliseExternalHostname(sanitized);
+    if (!canonical) {
+      continue;
+    }
+
+    if (isMarketingCloudProxyHost(canonical)) {
+      if (!proxyHost) {
+        proxyHost = sanitized;
+      }
+      continue;
+    }
+
+    return sanitized;
+  }
+
+  return proxyHost;
 }
 
 function normaliseProtocol(candidate) {
@@ -449,6 +493,35 @@ function firstHeaderValue(value) {
   }
 
   return value.split(',')[0].trim();
+}
+
+function collectHeaderValues(value) {
+  if (!value) {
+    return [];
+  }
+
+  const appendTokens = (acc, item) => {
+    if (item === undefined || item === null) {
+      return acc;
+    }
+
+    const tokens = String(item)
+      .split(',')
+      .map((token) => token.trim())
+      .filter(Boolean);
+
+    return acc.concat(tokens);
+  };
+
+  if (Array.isArray(value)) {
+    return value.reduce(appendTokens, []);
+  }
+
+  if (typeof value !== 'string') {
+    return [];
+  }
+
+  return appendTokens([], value);
 }
 
 function resolveForwardedProto(value) {
@@ -499,7 +572,7 @@ function isMarketingCloudProxyHost(host) {
     return false;
   }
 
-  const value = String(host).trim().toLowerCase();
+  const value = normaliseExternalHostname(host);
   if (!value) {
     return false;
   }
@@ -508,6 +581,32 @@ function isMarketingCloudProxyHost(host) {
     value.endsWith('marketingcloudapps.com') ||
     value.endsWith('marketingcloudsites.com') ||
     value.endsWith('marketingcloudsite.com');
+}
+
+function normaliseExternalHostname(host) {
+  if (!host) {
+    return '';
+  }
+
+  let value = String(host).trim();
+  if (!value) {
+    return '';
+  }
+
+  if (value.startsWith('[')) {
+    const closingIndex = value.indexOf(']');
+    value = closingIndex >= 0 ? value.slice(1, closingIndex) : value.slice(1);
+  }
+
+  if (value.includes(':')) {
+    if (value.includes('.')) {
+      value = value.split(':')[0];
+    } else if (!value.includes('::')) {
+      value = value.split(':')[0];
+    }
+  }
+
+  return value.trim().replace(/\.+$/, '').toLowerCase();
 }
 
 function isLocalHost(host) {


### PR DESCRIPTION
## Summary
- capture the first forwarded Marketing Cloud hostname as a fallback candidate when filtering proxy hosts for config.json
- prefer non-proxy forwarded hosts but allow Marketing Cloud domains when no other options are present

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3c41acc288330828ecceabbe82d34