### PR TITLE
Fix fallback host resolution for Marketing Cloud proxy hosts

### DIFF
--- a/modules/custom-activity/config/config-json.js
+++ b/modules/custom-activity/config/config-json.js
@@ -432,12 +432,14 @@ function resolvePrimaryExternalHost(candidates = []) {
 }
 
 function resolveExternalHostFallback(candidates = []) {
-
   let proxyHost = '';
+
+  for (const candidate of candidates) {
     const sanitized = sanitizeExternalHost(candidate, { allowProxyHosts: true });
     if (!sanitized) {
       continue;
     }
+
     const canonical = normaliseExternalHostname(sanitized);
     if (!canonical) {
       continue;
@@ -449,8 +451,12 @@ function resolveExternalHostFallback(candidates = []) {
       }
       continue;
     }
+
     return sanitized;
   }
+
+  return proxyHost || '';
+}
 
 
 


### PR DESCRIPTION
## Summary
- repair resolveExternalHostFallback to iterate over candidates when choosing a public host
- return the first non-proxy host or fall back to the first proxy host when none are available

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3cbeee3848330b754699a88eba53d