### PR TITLE
Remove static DE integration key fallback

### DIFF
--- a/modules/custom-activity/config/config-json.js
+++ b/modules/custom-activity/config/config-json.js
@@ -10,7 +10,7 @@ const envActivityExtensionKey =
 const envContactAttributeKey =
   process.env.ACTIVITY_CONTACT_DE_KEY ??
   process.env.DATA_EXTENSION_KEY ??
-  '170E7DC6-4174-40F9-8166-8681DD916F9B';
+  'DE';
 const ENV_ORIGIN = envConfig?.origin;
 const ENV_PATH = envConfig?.path;
 


### PR DESCRIPTION
## Summary
- remove the hard-coded data extension integration key fallback from the config json builder
- default the contact attribute key to the generic `DE` placeholder when no environment variables are provided

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3e16ef18c8330b3e6c6e3e02fe989